### PR TITLE
convert encode/decode_as_primitive kwargs to encode/decode_cell_type kwargs

### DIFF
--- a/src/xtal2png/utils/data.py
+++ b/src/xtal2png/utils/data.py
@@ -192,7 +192,35 @@ def rgb_unscaler(
     return X_scaled
 
 
-def get_image_mode(d):
+def get_image_mode(d: np.ndarray) -> str:
+    """Get the image mode (i.e. "RGB" vs. grayscale ("L")) for an image array.
+
+    Parameters
+    ----------
+    d : np.ndarray
+        A NumPy array with 3 dimensions, where the first dimension corresponds to the
+      of image channels and the second and third dimensions correspond to the height and
+      width of the image.
+
+    Returns
+    -------
+    mode : str
+        "RGB" for 3-channel images and "L" for grayscale images.
+
+    Raises
+    ------
+    ValueError
+        "expected an array with 3 dimensions, received {d.ndim} dims"
+    ValueError
+        "Expected a single-channel or 3-channel array, but received a {d.ndim}-channel
+        array."
+
+    Examples
+    --------
+    >>> d = np.zeros((1, 64, 64), dtype=np.uint8) # grayscale image
+    >>> mode = get_image_mode(d)
+    OUTPUT
+    """
     if d.ndim != 3:
         raise ValueError("expected an array with 3 dimensions, received {d.ndim} dims")
     if d.shape[0] == 3:

--- a/src/xtal2png/utils/data.py
+++ b/src/xtal2png/utils/data.py
@@ -219,7 +219,7 @@ def get_image_mode(d: np.ndarray) -> str:
     --------
     >>> d = np.zeros((1, 64, 64), dtype=np.uint8) # grayscale image
     >>> mode = get_image_mode(d)
-    OUTPUT
+    "L"
     """
     if d.ndim != 3:
         raise ValueError("expected an array with 3 dimensions, received {d.ndim} dims")

--- a/src/xtal2png/utils/data.py
+++ b/src/xtal2png/utils/data.py
@@ -5,6 +5,7 @@ import numpy as np
 from numpy.typing import ArrayLike
 from pymatgen.core.lattice import Lattice
 from pymatgen.core.structure import Structure
+from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 
 coords = [[0, 0, 0], [0.75, 0.5, 0.75]]
 lattice = Lattice.from_parameters(a=3.84, b=3.84, c=3.84, alpha=120, beta=90, gamma=60)
@@ -204,3 +205,49 @@ def get_image_mode(d):
         )
 
     return mode
+
+
+def unit_cell_converter(
+    s: Structure, cell_type: Optional[str] = None, symprec=0.1, angle_tolerance=5.0
+):
+    """Convert from the original unit cell type to another unit cell via pymatgen.
+
+    Parameters
+    ----------
+    s : Structure
+        a pymatgen Structure.
+    cell_type : Optional[str], optional
+        The cell type as a str or None if leaving the structure as-is. Possible options
+        are "primitive_standard", "refined", "reduced", and None. By default None
+
+    Returns
+    -------
+    s : Structure
+        The converted Structure.
+
+    Raises
+    ------
+    ValueError
+        "Expected one of 'primitive_standard', 'refined', 'reduced' or None, got
+        {cell_type}"
+
+    Examples
+    --------
+    >>> s = unit_cell_converter(s, cell_type="reduced")
+    """
+    spa = SpacegroupAnalyzer(
+        s,
+        symprec=symprec,
+        angle_tolerance=angle_tolerance,
+    )
+    if cell_type == "primitive_standard":
+        s = spa.get_primitive_standard_structure()
+    elif cell_type == "refined":
+        s = spa.get_refined_structure()
+    elif cell_type == "niggli":
+        s = s.get_reduced_structure()
+    elif cell_type is not None:
+        raise ValueError(
+            f"Expected one of 'primitive_standard', 'refined', 'reduced' or None, got {cell_type}"  # noqa: E501
+        )
+    return s

--- a/src/xtal2png/utils/data.py
+++ b/src/xtal2png/utils/data.py
@@ -218,7 +218,8 @@ def unit_cell_converter(
         a pymatgen Structure.
     cell_type : Optional[str], optional
         The cell type as a str or None if leaving the structure as-is. Possible options
-        are "primitive_standard", "refined", "reduced", and None. By default None
+        are "primitive_standard", "conventional_standard", "refined", "reduced", and
+        None. By default None
 
     Returns
     -------
@@ -228,8 +229,8 @@ def unit_cell_converter(
     Raises
     ------
     ValueError
-        "Expected one of 'primitive_standard', 'refined', 'reduced' or None, got
-        {cell_type}"
+        "Expected one of 'primitive_standard', 'conventional_standard', 'refined',
+        'reduced' or None, got {cell_type}"
 
     Examples
     --------
@@ -242,12 +243,14 @@ def unit_cell_converter(
     )
     if cell_type == "primitive_standard":
         s = spa.get_primitive_standard_structure()
+    elif cell_type == "conventional_standard":
+        s = spa.get_conventional_standard_structure()
     elif cell_type == "refined":
         s = spa.get_refined_structure()
-    elif cell_type == "niggli":
+    elif cell_type == "reduced":
         s = s.get_reduced_structure()
     elif cell_type is not None:
         raise ValueError(
-            f"Expected one of 'primitive_standard', 'refined', 'reduced' or None, got {cell_type}"  # noqa: E501
+            f"Expected one of 'primitive_standard', 'conventional_standard', 'refined', 'reduced' or None, got {cell_type}"  # noqa: E501
         )
     return s

--- a/tests/xtal2png_test.py
+++ b/tests/xtal2png_test.py
@@ -242,8 +242,8 @@ def test_primitive_encoding():
     xc = XtalConverter(
         symprec=0.1,
         angle_tolerance=5.0,
-        encode_as_primitive=True,
-        decode_as_primitive=False,
+        encode_cell_type="primitive_standard",
+        decode_cell_type=None,
         relax_on_decode=False,
     )
     input_structures = [
@@ -264,8 +264,8 @@ def test_primitive_decoding():
     xc = XtalConverter(
         symprec=0.1,
         angle_tolerance=5.0,
-        encode_as_primitive=False,
-        decode_as_primitive=True,
+        encode_cell_type=None,
+        decode_cell_type="primitive_standard",
         relax_on_decode=False,
     )
     input_structures = [

--- a/tests/xtal2png_test.py
+++ b/tests/xtal2png_test.py
@@ -150,7 +150,9 @@ def test_arrays_to_structures():
     xc = XtalConverter(relax_on_decode=False)
     data, id_data, id_mapper = xc.structures_to_arrays(example_structures)
     structures = xc.arrays_to_structures(data, id_data, id_mapper)
-    assert_structures_approximate_match(example_structures, structures)
+    assert_structures_approximate_match(
+        example_structures, structures, tol_multiplier=2.0
+    )
     return structures
 
 
@@ -160,7 +162,9 @@ def test_arrays_to_structures_zero_one():
         example_structures, rgb_scaling=False
     )
     structures = xc.arrays_to_structures(data, id_data, id_mapper, rgb_scaling=False)
-    assert_structures_approximate_match(example_structures, structures)
+    assert_structures_approximate_match(
+        example_structures, structures, tol_multiplier=2.0
+    )
     return structures
 
 
@@ -194,7 +198,9 @@ def test_png2xtal():
     xc = XtalConverter(relax_on_decode=False)
     imgs = xc.xtal2png(example_structures, show=True, save=True)
     decoded_structures = xc.png2xtal(imgs)
-    assert_structures_approximate_match(example_structures, decoded_structures)
+    assert_structures_approximate_match(
+        example_structures, decoded_structures, tol_multiplier=2.0
+    )
 
 
 def test_png2xtal_single():
@@ -221,7 +227,9 @@ def test_png2xtal_three_channels():
     if img_shape != (64, 64, 3):
         raise ValueError(f"Expected image shape: (3, 64, 64), received: {img_shape}")
     decoded_structures = xc.png2xtal(imgs)
-    assert_structures_approximate_match(example_structures, decoded_structures)
+    assert_structures_approximate_match(
+        example_structures, decoded_structures, tol_multiplier=2.0
+    )
 
 
 def test_primitive_encoding():


### PR DESCRIPTION
i.e. take Optional[str] as input instead of bool

Created a unit_cell_converter convenience function

https://github.com/materialsproject/pymatgen/issues/2474