### PR TITLE
allow for masking out redundant info from representation

### DIFF
--- a/src/xtal2png/core.py
+++ b/src/xtal2png/core.py
@@ -145,6 +145,11 @@ class XtalConverter:
         func:``XtalConverter().arrays_to_structures`` directly instead.
     verbose: bool, optional
         Whether to print verbose debugging information or not.
+    mask_types : List[str], optional
+        List of information types to mask out (assign as 0) from the array/image. values
+        are "atom", "frac", "latt_a", "latt_b", "latt_c", "angles", "volume",
+        "space_group", "distance", and None. If None, then no masking is applied. By
+        default, None.
 
     Examples
     --------
@@ -173,6 +178,7 @@ class XtalConverter:
         relax_on_decode: bool = False,
         channels: int = 1,
         verbose: bool = True,
+        mask_types: List[str] = None,
     ):
         """Instantiate an XtalConverter object with desired ranges and ``max_sites``."""
         self.atom_range = atom_range
@@ -212,6 +218,8 @@ class XtalConverter:
             self.tqdm_if_verbose = tqdm
         else:
             self.tqdm_if_verbose = lambda x: x
+
+        self.mask_types = mask_types
 
         Path(save_dir).mkdir(exist_ok=True, parents=True)
 
@@ -299,9 +307,29 @@ class XtalConverter:
         self,
         structures: List[Union[Structure, str, "PathLike[str]"]],
         y=None,
-        fit_quantiles=(0.00, 0.99),
-        verbose=None,
+        fit_quantiles: Tuple[float, float] = (0.00, 0.99),
+        verbose: Optional[bool] = None,
     ):
+        """Find optimal range parameters for encoding crystal structures.
+
+        Parameters
+        ----------
+        structures : List[Union[Structure, str, "PathLike[str]"]]
+            List of pymatgen Structure objects.
+        y : NoneType, optional
+            No effect, for compatibility only, by default None
+        fit_quantiles : Tuple[float,float], optional
+            The lower and upper quantiles to use for fitting ranges to the data, by
+            default (0.00, 0.99)
+        verbose : Optional[bool], optional
+            Whether to print information about the fitted ranges. If None, then defaults
+            to ``self.verbose``. By default None
+
+        Examples
+        --------
+        >>> fit(structures, , y=None, fit_quantiles=(0.00, 0.99), verbose=None, )
+        OUTPUT
+        """
         verbose = self.verbose if verbose is None else verbose
 
         _, S = self.process_filepaths_or_structures(structures)

--- a/src/xtal2png/core.py
+++ b/src/xtal2png/core.py
@@ -59,9 +59,9 @@ DISTANCE_ID = 9
 
 ATOM_KEY = "atom"
 FRAC_KEY = "frac"
-A_KEY = "latt_a"
-B_KEY = "latt_b"
-C_KEY = "latt_c"
+A_KEY = "a"
+B_KEY = "b"
+C_KEY = "c"
 ANGLES_KEY = "angles"
 VOLUME_KEY = "volume"
 SPACE_GROUP_KEY = "space_group"
@@ -159,7 +159,7 @@ class XtalConverter:
         Whether to print verbose debugging information or not.
     mask_types : List[str], optional
         List of information types to mask out (assign as 0) from the array/image. values
-        are "atom", "frac", "latt_a", "latt_b", "latt_c", "angles", "volume",
+        are "atom", "frac", "a", "b", "c", "angles", "volume",
         "space_group", "distance", and None. If None, then no masking is applied. By
         default, None.
 

--- a/tests/xtal2png_test.py
+++ b/tests/xtal2png_test.py
@@ -354,7 +354,7 @@ def test_plot_and_save():
 
 def test_distance_mask():
     xc = XtalConverter(mask_types=["distance"])
-    imgs = xc.structures_to_arrays(example_structures)
+    imgs = xc.xtal2png(example_structures)
     if not np.all(xc.data[xc.id_data == xc.id_mapper["distance"]] == 0):
         raise ValueError("Distance mask not applied correctly (id_mapper)")
 
@@ -364,10 +364,22 @@ def test_distance_mask():
     return imgs
 
 
+def test_mask_error():
+    xc = XtalConverter(mask_types=["atom"])
+    imgs = xc.xtal2png(example_structures)
+
+    decoded_structures = xc.png2xtal(imgs)
+
+    for s in decoded_structures:
+        if s.num_sites > 0:
+            raise ValueError("Atom mask should have wiped out atomic sites.")
+
+
 # TODO: test_matplotlibify with assertion
 
 
 if __name__ == "__main__":
+    test_mask_error()
     test_distance_mask()
     test_xtal2png_three_channels()
     test_png2xtal_three_channels()

--- a/tests/xtal2png_test.py
+++ b/tests/xtal2png_test.py
@@ -364,6 +364,15 @@ def test_distance_mask():
     return imgs
 
 
+def test_lower_tri_mask():
+    xc = XtalConverter(mask_types=["lower_tri"])
+    imgs = xc.xtal2png(example_structures)
+    if not np.all(xc.data[np.tril(xc.data[0, 0])] == 0):
+        raise ValueError("Lower triangle mask not applied correctly")
+
+    return imgs
+
+
 def test_mask_error():
     xc = XtalConverter(mask_types=["atom"])
     imgs = xc.xtal2png(example_structures)
@@ -379,6 +388,7 @@ def test_mask_error():
 
 
 if __name__ == "__main__":
+    test_lower_tri_mask()
     test_mask_error()
     test_distance_mask()
     test_xtal2png_three_channels()

--- a/tests/xtal2png_test.py
+++ b/tests/xtal2png_test.py
@@ -352,10 +352,23 @@ def test_plot_and_save():
     plot_and_save("reports/figures/tmp", fig, mpl_kwargs={})
 
 
+def test_distance_mask():
+    xc = XtalConverter(mask_types=["distance"])
+    imgs = xc.structures_to_arrays(example_structures)
+    if not np.all(xc.data[xc.id_data == xc.id_mapper["distance"]] == 0):
+        raise ValueError("Distance mask not applied correctly (id_mapper)")
+
+    if not np.all(xc.data[:, :, 12:, 12:] == 0):
+        raise ValueError("Distance mask not applied correctly (hardcoded)")
+
+    return imgs
+
+
 # TODO: test_matplotlibify with assertion
 
 
 if __name__ == "__main__":
+    test_distance_mask()
     test_xtal2png_three_channels()
     test_png2xtal_three_channels()
     test_structures_to_arrays_zero_one()


### PR DESCRIPTION
closes #135 

Doesn't remove, just sets the corresponding values to zero.